### PR TITLE
Allow scanning local docker images

### DIFF
--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -31,6 +31,9 @@ func isExcluded(v *ExtendedVulnerability, ex *[]config.Exclusion) bool {
 }
 
 func updateReport(e *ExtendedVulnerability, c *config.Check) {
+	if c.NewTarget == "" || c.NewTarget != c.Target {
+		return
+	}
 	e.Target = c.Target
 	e.Details = strings.ReplaceAll(e.Details, c.NewTarget, c.Target)
 	e.AffectedResource = strings.ReplaceAll(e.AffectedResource, c.NewTarget, c.Target)

--- a/script/test.sh
+++ b/script/test.sh
@@ -18,6 +18,12 @@ echo "Test local path as a git repository excluding the github check"
 ./vulcan-local -t . -e github -u file://./script/checktypes-stable.json
 echo "exit=$?"
 
+# Add a path and a tag to bypass check target validations.
+docker tag vulcan-local path/vulcan-local:xxx
+echo "Test local docker image"
+./vulcan-local -t path/vulcan-local:xxx -a DockerImage -i trivy -u file://./script/checktypes-stable.json
+echo "exit=$?"
+
 echo "Docker test based on yaml config"
 docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock  \
     -v "$PWD":/target -e TRAVIS_BUILD_DIR=/target \


### PR DESCRIPTION
This allow to scan local images by mounting the docker socket into the checks.

If the check looks into the docker socket it will find the image available without having to pull it.
