### PR TITLE
Report a warning when a required variable is missing.

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -98,6 +98,8 @@ func Run(cfg *config.Config, log *logrus.Logger) (int, error) {
 		return config.SuccessExitCode, nil
 	}
 
+	checkRequiredVariables(cfg, log)
+
 	// AWS Credentials are required for sqs
 	os.Setenv("AWS_REGION", "local")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "TBD")
@@ -359,4 +361,17 @@ func GetHostIP(l agentlog.Logger) string {
 	ip := strings.TrimSuffix(cmdOut.String(), "\n")
 	l.Debugf("Hostip=%s", ip)
 	return ip
+}
+
+// checkRequiredVariables checks that all the required variables are configured and
+// report a warn if they are not
+func checkRequiredVariables(cfg *config.Config, log *logrus.Logger) {
+	for _, check := range cfg.Checks {
+		for _, requiredVar := range check.Checktype.RequiredVars {
+			if val, ok := cfg.Conf.Vars[requiredVar]; ok && len(val) == 0 || !ok {
+				log.Warnf("Missing required variable %s for the check %s and the target %s. "+
+					"The check may fail or not be executed.", requiredVar, check.Checktype.Name, check.Target)
+			}
+		}
+	}
 }

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -369,7 +369,7 @@ func checkRequiredVariables(cfg *config.Config, log *logrus.Logger) {
 	for _, check := range cfg.Checks {
 		for _, requiredVar := range check.Checktype.RequiredVars {
 			if val, ok := cfg.Conf.Vars[requiredVar]; ok && len(val) == 0 || !ok {
-				log.Warnf("Missing required variable %s for the check %s and the target %s. "+
+				log.Warnf("Missing required variable %s for the check %s and the target \"%s\". "+
 					"The check may fail or not be executed.", requiredVar, check.Checktype.Name, check.Target)
 			}
 		}


### PR DESCRIPTION
Vulcan checks can have required variables to run. When using them with vulcan-local, the tool doesn't check if these variables have been set or not, and tries to run the check anyway. Some checks will run successfully in some conditions even when the required variables aren't set, but others will fail silently.
The objective is to validate in vulcan-local if the required variables for a given Vulcan check are set before running it, notify the user in case they are not, and then run the check. This would make it easier for the users to understand why a check is failing in some cases.