### PR TITLE
Log an info message when an exclusion has no description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ When specified, it applies a `contains` evaluation over the following fields:
 - affectedResource: Applies either to `affectedResource` and `affectedResourceString`
 - target
 - fingerprint
+- description: A brief explanation as to why the finding should be excluded from the report.
 
 ```yaml
 reporting:
@@ -206,8 +207,10 @@ reporting:
     - summary: Leaked
     - affectedResource: libgcrypt
       target: .
+      description: "libgcrypt has a known and accepted vulnerability."
     - affectedResource: busybox
       target: .
+      description: "busybox is not relevant"
     - affectedResource: ncurses
       target: latest
     - fingerprint: 7820aa24a96f0fcd4717933772a8bc89552a0c1509f3d90b14d885d25e60595f

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,6 +89,7 @@ type Exclusion struct {
 	Summary          string `yaml:"summary"`
 	AffectedResource string `yaml:"affectedResource"`
 	Fingerprint      string `yaml:"fingerprint"`
+	Description      string `yaml:"description"`
 }
 
 type Reporting struct {

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -76,6 +76,22 @@ func parseReports(reports map[string]*report.Report, cfg *config.Config, l log.L
 	return vulns
 }
 
+// checkExclusionDescriptions checks that the exlusions have the description
+func checkExclusionDescriptions(cfg *config.Config, l log.Logger) {
+
+	for _, e := range cfg.Reporting.Exclusions {
+		if e.Description == "" {
+			l.Infof("Missing description for the exclusion:\n"+
+				" - Target: %s\n"+
+				" - Summary: %s\n"+
+				" - AffectedResource: %s\n"+
+				" - Fingerprint:  %s\n",
+				e.Target, e.Summary, e.AffectedResource, e.Fingerprint)
+
+		}
+	}
+}
+
 func ShowSummary(cfg *config.Config, results *results.ResultsServer, l log.Logger) {
 	buf := new(bytes.Buffer)
 	fmt.Fprint(buf, "\nCheck summary:\n\n")
@@ -134,6 +150,8 @@ func Generate(cfg *config.Config, results *results.ResultsServer, l log.Logger) 
 	if cfg.Reporting.Format != "json" {
 		return config.ErrorExitCode, fmt.Errorf("report format unknown %s", cfg.Reporting.Format)
 	}
+
+	checkExclusionDescriptions(cfg, l)
 
 	requested := cfg.Reporting.Severity.Data()
 


### PR DESCRIPTION
Add the possibility of allowing vulcan-local users to add a description as a field for the exclusions when running checks.

This could already be done as comments in the yaml configuration file, but in order to encourage the users to keep track of the exceptions, vulcan-local could raise an info log when an exclusion has been created without the description field.