### PR TITLE
feat: allow bare directories as GitRepository

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -196,7 +196,7 @@ func Run(cfg *config.Config, log *logrus.Logger) (int, error) {
 			rc.ContainerConfig.Env = upsertEnv(rc.ContainerConfig.Env, backend.CheckAssetTypeVar, "LocalDockerImage")
 		} else if params.AssetType == "GitRepository" {
 
-			if path, err := generator.GetValidGitDirectory(params.Target); err == nil {
+			if path, err := generator.GetValidDirectory(params.Target); err == nil {
 				port, err := gs.AddGit(path)
 				if err != nil {
 					log.Errorf("Unable to create local git server check %v", err)

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -146,7 +146,7 @@ func getTypesFromIdentifier(target config.Target) ([]config.Target, error) {
 		return []config.Target{a}, nil
 	}
 
-	if _, err := GetValidGitDirectory(identifier); err == nil {
+	if _, err := GetValidDirectory(identifier); err == nil {
 		a.AssetType = "GitRepository"
 		return []config.Target{a}, nil
 	}
@@ -356,18 +356,6 @@ func filterChecktype(name string, include, exclude *regexp.Regexp) bool {
 		return false
 	}
 	return true
-}
-
-func GetValidGitDirectory(path string) (string, error) {
-	path, err := GetValidDirectory(path)
-	if err != nil {
-		return "", err
-	}
-	_, err = GetValidDirectory(filepath.Join(path, ".git"))
-	if err != nil {
-		return "", err
-	}
-	return path, nil
 }
 
 func GetValidDirectory(path string) (string, error) {

--- a/pkg/generator/generator_test.go
+++ b/pkg/generator/generator_test.go
@@ -474,6 +474,19 @@ func TestGetTypesFromIdentifier(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		{
+			name: "Resolve to local GitRepository",
+			target: config.Target{
+				Target: ".",
+			},
+			want: []config.Target{
+				{
+					Target:    ".",
+					AssetType: "GitRepository",
+				},
+			},
+			wantErr: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Since #11 the path of a local directory no longer needs to point to the root of a git folder to be scanned as a GitRepository.
This is because now the content is copied to a temporary location and a new git repo is served from there on the fly.

This pr relaxes the validation of the path provided allowing any directory as a target.