### PR TITLE
Send report in the selected format to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ Usage of vulcan-local:
     	docker binary (default "docker")
   -e string
     	exclude checktype regex
-  -f string
-    	output format (eg report, json) (default "report")
+  -f value
+    	output format [json report] (Default "report")
   -git string
     	git binary (default "git")
   -h	print usage
@@ -169,11 +169,14 @@ vulcan-local -t http://localhost:1234 -e zap
 # Execute all checks on WebAddress with the indicated option.
 vulcan-local -t http://localhost:1234 -o '{"depth": 1}'
 
-# Execute all checks for GitRepository targets (. has to be the root of a git repo)
+# Execute all checks for GitRepository targets
 vulcan-local -t . -a GitRepository
 
 # Execute all checks . inferring the asset type
 vulcan-local -t .
+
+# Get the results in json format
+vulcan-local -t . -f json | jq .
 ```
 
 ### Running local checks

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Usage of vulcan-local:
     	docker binary (default "docker")
   -e string
     	exclude checktype regex
+  -f string
+    	output format (eg report, json) (default "report")
   -git string
     	git binary (default "git")
   -h	print usage
@@ -117,13 +119,14 @@ Usage of vulcan-local:
   -pullpolicy value
     	when to pull for check images [Always IfNotPresent Never] (Default "IfNotPresent")
   -r string
-    	results file (eg results.json)
+    	results file, defaults to stdout (eg results.json)
   -s value
     	filter by severity [CRITICAL HIGH MEDIUM LOW INFO] (Default "HIGH")
   -t value
     	target to scan (eg .)
   -version
     	print version
+
 ```
 
 Exit codes:

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 			Vars:        map[string]string{},
 		},
 		Reporting: config.Reporting{
-			Format:   "report",
+			Format:   config.FormatReport,
 			Severity: config.SeverityHigh,
 		},
 		CheckTypes: map[checktypes.ChecktypeRef]checktypes.Checktype{},
@@ -94,7 +94,9 @@ func main() {
 		return cfg.Conf.LogLevel.UnmarshalText([]byte(s))
 	})
 	flag.StringVar(&cfg.Conf.Policy, "p", "", "policy to execute")
-	flag.StringVar(&cfg.Reporting.Format, "f", cfg.Reporting.Format, "output format (eg report, json)")
+	flag.Func("f", genFlagMsg("output format", "", cfg.Reporting.Format.String(), "", config.ReportFormatNames()), func(s string) error {
+		return cfg.Reporting.Format.UnmarshalText([]byte(s))
+	})
 	flag.StringVar(&cfg.Reporting.OutputFile, "r", "", "results file, defaults to stdout (eg results.json)")
 	flag.StringVar(&cfg.Conf.Include, "i", cfg.Conf.Include, "include checktype regex")
 	flag.StringVar(&cfg.Conf.Exclude, "e", cfg.Conf.Exclude, "exclude checktype regex")

--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 			Vars:        map[string]string{},
 		},
 		Reporting: config.Reporting{
-			Format:   "json",
+			Format:   "report",
 			Severity: config.SeverityHigh,
 		},
 		CheckTypes: map[checktypes.ChecktypeRef]checktypes.Checktype{},
@@ -94,7 +94,8 @@ func main() {
 		return cfg.Conf.LogLevel.UnmarshalText([]byte(s))
 	})
 	flag.StringVar(&cfg.Conf.Policy, "p", "", "policy to execute")
-	flag.StringVar(&cfg.Reporting.OutputFile, "r", "", "results file (eg results.json)")
+	flag.StringVar(&cfg.Reporting.Format, "f", cfg.Reporting.Format, "output format (eg report, json)")
+	flag.StringVar(&cfg.Reporting.OutputFile, "r", "", "results file, defaults to stdout (eg results.json)")
 	flag.StringVar(&cfg.Conf.Include, "i", cfg.Conf.Include, "include checktype regex")
 	flag.StringVar(&cfg.Conf.Exclude, "e", cfg.Conf.Exclude, "exclude checktype regex")
 	flag.Func("t", genFlagMsg("target to scan", ".", "", "", nil), func(s string) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,10 +90,10 @@ type Exclusion struct {
 }
 
 type Reporting struct {
-	Severity   Severity    `yaml:"severity"`
-	Format     string      `yaml:"format"`
-	OutputFile string      `yaml:"outputFile"`
-	Exclusions []Exclusion `yaml:"exclusions"`
+	Severity   Severity     `yaml:"severity"`
+	Format     ReportFormat `yaml:"format"`
+	OutputFile string       `yaml:"outputFile"`
+	Exclusions []Exclusion  `yaml:"exclusions"`
 }
 
 type Severity int
@@ -104,6 +104,13 @@ const (
 	SeverityMedium
 	SeverityLow
 	SeverityInfo
+)
+
+type ReportFormat int
+
+const (
+	FormatJSON ReportFormat = iota
+	FormatReport
 )
 
 const (
@@ -214,6 +221,42 @@ func FindSeverityByScore(score float32) Severity {
 		}
 	}
 	return severities[len(severities)-1].Severity
+}
+
+var reportFormatString = map[ReportFormat]string{
+	FormatJSON:   "json",
+	FormatReport: "report",
+}
+
+func (f *ReportFormat) String() string {
+	if a, ok := reportFormatString[*f]; ok {
+		return a
+	}
+	return "unknown"
+}
+
+func (a *ReportFormat) MarshalText() (text []byte, err error) {
+	return []byte(a.String()), nil
+}
+
+// UnmarshalText creates a Severity from its string representation.
+func (a *ReportFormat) UnmarshalText(text []byte) error {
+	val := string(text)
+	for k, v := range reportFormatString {
+		if v == val {
+			*a = k
+			return nil
+		}
+	}
+	return fmt.Errorf("error value %s is not a valid ReportFormat value", val)
+}
+
+func ReportFormatNames() []string {
+	s := []string{}
+	for _, v := range reportFormatString {
+		s = append(s, v)
+	}
+	return s
 }
 
 func ReadConfig(url string, cfg *Config, l log.Logger) error {

--- a/pkg/reporting/cliwriter.go
+++ b/pkg/reporting/cliwriter.go
@@ -29,10 +29,10 @@ type ExtendedVulnerability struct {
 	Excluded bool
 }
 
-func summaryTable(s []ExtendedVulnerability, l log.Logger) {
+func summaryTable(s []ExtendedVulnerability, l log.Logger) string {
 	if len(s) == 0 {
 		l.Infof("No vulnerabilities found during the last scan")
-		return
+		return ""
 	}
 	data := make(map[config.Severity]int)
 	excluded := 0
@@ -57,7 +57,8 @@ func summaryTable(s []ExtendedVulnerability, l log.Logger) {
 		fmt.Fprintf(buf, "\nNumber of excluded vulnerabilities: %d\n", excluded)
 	}
 	fmt.Fprint(buf, "\n")
-	l.Infof(buf.String())
+
+	return buf.String()
 }
 
 func printVulnerability(v *ExtendedVulnerability, l log.Logger) string {

--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -203,7 +203,7 @@ func Generate(cfg *config.Config, results *results.ResultsServer, l log.Logger) 
 	vs := parseReports(results.Checks, cfg, l)
 
 	// TODO: Unify filtering for all the formats.
-	if cfg.Reporting.Format == "json" {
+	if cfg.Reporting.Format == config.FormatJSON {
 		// TODO: Decide if we want to keep filtering JSON output by threshold and exclusion
 		// Recreates the original report map filtering the Excluded and Threshold
 		// json: Just print the reports as an slice
@@ -222,7 +222,7 @@ func Generate(cfg *config.Config, results *results.ResultsServer, l log.Logger) 
 		}
 		str, _ := json.MarshalIndent(slice, "", "  ")
 		fmt.Fprint(output, string(str))
-	} else if cfg.Reporting.Format == "report" {
+	} else if cfg.Reporting.Format == config.FormatReport {
 		var sb strings.Builder
 		for _, s := range config.Severities() {
 			sd := s.Data()
@@ -236,8 +236,7 @@ func Generate(cfg *config.Config, results *results.ResultsServer, l log.Logger) 
 		fmt.Fprint(output, summaryTable(vs, l))
 		fmt.Fprint(output, sb.String())
 	} else {
-		// TODO: Create an enum and validate on command parsing.
-		return config.ErrorExitCode, fmt.Errorf("report format unknown %s", cfg.Reporting.Format)
+		return config.ErrorExitCode, fmt.Errorf("report format unknown %s", cfg.Reporting.Format.String())
 	}
 
 	// Get max reported score in vulnerabilities

--- a/vulcan.yaml
+++ b/vulcan.yaml
@@ -61,7 +61,6 @@ checks:
     target: appsecco/dsvw:latest
 
 reporting:
-  format: json
   # Valid values CRITICAL, *HIGH*, MEDIUM, LOW, INFO (default HIGH)
   severity: HIGH
   exclusions:


### PR DESCRIPTION
Send the report to stdout (now is mixed with the logs).
Add `-f` to select the format (`report` / `json`) `report` is the default. The current report is the default.

This allows to pipe the report.
```sh
vulcan-local -t . -f json | jq .
```

Now those command will send the report to the file.

```sh
vulcan-local -t -r out.txt 
vulcan-local -t > out.txt 
```

**ON HOLD because this prevents to get the visual report and the json at the same time.**
