### PR TITLE
fix: keep support for file schema but plan deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is a very simple config file with two checks:
 ```yaml
 conf:
   repositories:
-    - file://./script/checktypes-stable.json
+    - ./script/checktypes-stable.json
 
 # List of targets to scan generating checks from all available checktypes
 targets:
@@ -152,10 +152,10 @@ cat ~/my_password.txt | docker login --username foo --password-stdin private.reg
 Scan a single asset with all the checkTypes that apply
 
 ```sh
-vulcan-local -t http://localhost:1234 -i exposed -checktypes file://./script/checktypes-stable.json
+vulcan-local -t http://localhost:1234 -i exposed -checktypes ./script/checktypes-stable.json
 
 # Set VULCAN_CHECKTYPES as the default checktypes uri (-checktypes flag)
-export VULCAN_CHECKTYPES=file://./script/checktypes-stable.json
+export VULCAN_CHECKTYPES=./script/checktypes-stable.json
 
 # Execute all checks on WebAddress that matches 'exposed' regex
 vulcan-local -t http://localhost:1234 -i exposed
@@ -266,7 +266,7 @@ Start scanning a local http server
 docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
     -v $PWD/script:/app/script \
     -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
-    vulcan-local -t http://localhost:1234 -checktypes file:///app/script/checktypes-stable.json
+    vulcan-local -t http://localhost:1234 -checktypes /app/script/checktypes-stable.json
 ```
 
 Start scanning a local Git repository. **The target path must point to the base of a git repository.**
@@ -275,5 +275,5 @@ Start scanning a local Git repository. **The target path must point to the base 
 docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
   -v $PWD/script:/app/script -v $PWD:/src \
   -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
-  vulcan-local -t /src -checktypes file:///app/script/checktypes-stable.json
+  vulcan-local -t /src -checktypes /app/script/checktypes-stable.json
 ```

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -55,7 +55,6 @@ func Run(cfg *config.Config, log *logrus.Logger) (int, error) {
 			return config.ErrorExitCode, fmt.Errorf("invalid exclude regexp: %w", err)
 		}
 	}
-	log.Debugf("Importing checktypes from: %+v", cfg.Conf.Repositories)
 	checktypes, err := checktypes.Import(cfg.Conf.Repositories, log)
 	if err != nil {
 		return config.ErrorExitCode, fmt.Errorf("unable to load repositories: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,7 @@ import (
 	neturl "net/url"
 	"reflect"
 	"regexp"
+	"strings"
 
 	agentconfig "github.com/adevinta/vulcan-agent/config"
 	"github.com/adevinta/vulcan-agent/log"
@@ -216,6 +217,11 @@ func FindSeverityByScore(score float32) Severity {
 }
 
 func ReadConfig(url string, cfg *Config, l log.Logger) error {
+	if strings.HasPrefix(url, "file://") {
+		l.Infof("Removing 'file://' from %s. This support will be deprecated in future versions", url)
+		url = strings.TrimPrefix(url, "file://")
+	}
+
 	u, err := neturl.Parse(url)
 	if err != nil {
 		return err

--- a/script/test.sh
+++ b/script/test.sh
@@ -15,13 +15,13 @@ echo "Test based on yaml config using lightweight policy"
 echo "exit=$?"
 
 echo "Test local path as a git repository excluding the github check"
-./vulcan-local -t . -e github -checktypes file://./script/checktypes-stable.json
+./vulcan-local -t . -e github -checktypes ./script/checktypes-stable.json
 echo "exit=$?"
 
 # Add a path and a tag to bypass check target validations.
 docker tag vulcan-local path/vulcan-local:xxx
 echo "Test local docker image"
-./vulcan-local -t path/vulcan-local:xxx -a DockerImage -i trivy -checktypes file://./script/checktypes-stable.json
+./vulcan-local -t path/vulcan-local:xxx -a DockerImage -i trivy -checktypes ./script/checktypes-stable.json
 echo "exit=$?"
 
 echo "Docker test based on yaml config"
@@ -35,7 +35,7 @@ echo "Docker test local app as a webaddress excluding nessus and zap"
 docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock  \
     -v "$PWD":/target \
     -e TRAVIS_BUILD_DIR=/target -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
-    vulcan-local -t http://localhost:1234 -e '(nessus|zap)' -checktypes file:///target/script/checktypes-stable.json
+    vulcan-local -t http://localhost:1234 -e '(nessus|zap)' -checktypes /target/script/checktypes-stable.json
 echo "exit=$?"
 
 echo "Stopping target app"

--- a/vulcan.yaml
+++ b/vulcan.yaml
@@ -11,7 +11,7 @@ conf:
     REGISTRY_PASSWORD: ${REGISTRY_PASSWORD}
 
   repositories:
-    - file://${TRAVIS_BUILD_DIR:-.}/script/checktypes-stable.json
+    - ${TRAVIS_BUILD_DIR:-.}/script/checktypes-stable.json
 
   # Registry credentials to pull checks from private registries
   registries:


### PR DESCRIPTION
- The support for file:// checktypes was broken
- Remove references for file:// usage and warn about future deprecation
- Fixes the http / https support for checktypes