### PR TITLE
feat: lazy show message about missing req vars

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -102,8 +102,6 @@ func Run(cfg *config.Config, log *logrus.Logger) (int, error) {
 		return config.SuccessExitCode, nil
 	}
 
-	checkRequiredVariables(cfg, log)
-
 	// AWS Credentials are required for sqs
 	os.Setenv("AWS_REGION", "local")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "TBD")
@@ -381,19 +379,4 @@ func getCheckByID(checks []config.Check, id string) *config.Check {
 		}
 	}
 	return nil
-}
-
-// checkRequiredVariables checks that all the required variables are configured and
-// report a warn if they are not
-func checkRequiredVariables(cfg *config.Config, log *logrus.Logger) {
-	for _, check := range cfg.Checks {
-		if check.Checktype != nil {
-			for _, requiredVar := range check.Checktype.RequiredVars {
-				if val, ok := cfg.Conf.Vars[requiredVar]; !ok || len(val) == 0 {
-					log.Warnf("Missing required variable %s for the check %s and the target \"%s\". "+
-						"The check may fail or not be executed.", requiredVar, check.Checktype.Name, check.Target)
-				}
-			}
-		}
-	}
 }

--- a/pkg/cmd/main_test.go
+++ b/pkg/cmd/main_test.go
@@ -5,7 +5,6 @@ Copyright 2022 Adevinta
 package cmd
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,8 +12,6 @@ import (
 	"testing"
 	"time"
 
-	agentlog "github.com/adevinta/vulcan-agent/log"
-	"github.com/adevinta/vulcan-local/pkg/checktypes"
 	"github.com/adevinta/vulcan-local/pkg/config"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
@@ -207,105 +204,6 @@ func TestCheckDependencies(t *testing.T) {
 					}
 				}
 			}
-		})
-	}
-
-}
-
-func TestCheckRequiredVariables(t *testing.T) {
-
-	buf := bytes.Buffer{}
-	loggerUser.SetOutput(&buf)
-
-	defer func() {
-		loggerUser.SetOutput(os.Stderr)
-	}()
-
-	tests := []struct {
-		name    string
-		cfg     *config.Config
-		want    []string
-		wantErr error
-	}{
-		{
-			name: "HappyPath",
-			cfg: &config.Config{
-				Conf: config.Conf{
-					Vars: map[string]string{
-						"A": "a",
-						"B": "b",
-						"C": "c",
-					},
-				},
-				Checks: []config.Check{
-					{
-						Checktype: &checktypes.Checktype{
-							RequiredVars: []string{"A", "B", "C"},
-						},
-					},
-				},
-			},
-			want:    []string{""},
-			wantErr: nil,
-		},
-		{
-			name: "Missing one Variable",
-			cfg: &config.Config{
-				Conf: config.Conf{
-					LogLevel: logrus.InfoLevel,
-					Vars: map[string]string{
-						"A": "a",
-						"B": "b",
-					},
-				},
-				Checks: []config.Check{
-					{
-						Checktype: &checktypes.Checktype{
-							RequiredVars: []string{"A", "B", "C"},
-						},
-					},
-				},
-			},
-			want:    []string{"Missing required variable C for the check"},
-			wantErr: nil,
-		},
-		{
-			name: "Missing two Variable",
-			cfg: &config.Config{
-				Conf: config.Conf{
-					LogLevel: logrus.InfoLevel,
-					Vars: map[string]string{
-						"A": "a",
-					},
-				},
-				Checks: []config.Check{
-					{
-						Checktype: &checktypes.Checktype{
-							RequiredVars: []string{"A", "B", "C"},
-						},
-					},
-				},
-			},
-			want: []string{
-				"Missing required variable B for the check",
-				"Missing required variable C for the check"},
-			wantErr: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			loggerUser.SetLevel(agentlog.ParseLogLevel(tt.cfg.Conf.LogLevel.String()))
-
-			checkRequiredVariables(tt.cfg, loggerUser)
-			got := buf.String()
-			for _, want := range tt.want {
-				if !strings.Contains(got, want) {
-					t.Errorf("Wanted %s, got %s", tt.want, got)
-				}
-			}
-			buf.Reset()
 		})
 	}
 }


### PR DESCRIPTION
Many checktypes accept required variables that are optional.
Every time a check is scheduled to be executed without informing some variable a warning appears.

This pr removes that warning and generates a log error when the check failed and some variables were missing.

```sh
# In this case the warning is removed as as the command is valid
vulcan-local -t . -i semgrep -checktypes https://adevinta.github.io/vulcan-checks/checktypes/edge.json

# In this case an error is logged as the check fails because of the required variables
vulcan-local -t . -i github-alerts -checktypes https://adevinta.github.io/vulcan-checks/checktypes/edge.json
```

