### PR TITLE
feat: pass variables through command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ vulcan-local -t .
 
 # See the report in json
 vulcan-local -t . -r - -l ERROR | jq .
+
+# Pass variables trough command line (those examples are equivalent)
+vulcan-local -t https://wordpress.org -i wpscan -v WPVULNDB_API_TOKEN
+vulcan-local -t https://wordpress.org -i wpscan -v WPVULNDB_API_TOKEN=$WPVULNDB_API_TOKEN
 ```
 
 Also the tool can be used to scan remote resources.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,6 @@ Start scanning a local http server
 ```sh
 docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
     -v $PWD/script:/app/script \
-    -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
     vulcan-local -t http://localhost:1234 -checktypes /app/script/checktypes-stable.json
 ```
 
@@ -291,6 +290,5 @@ Start scanning a local Git repository. **The target path must point to the base 
 ```sh
 docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
   -v $PWD/script:/app/script -v $PWD:/src \
-  -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
   vulcan-local -t /src -checktypes /app/script/checktypes-stable.json
 ```


### PR DESCRIPTION
The required variables must be explicitly added in order to prevent unwanted values.

```sh
WPVULNDB_API_TOKEN=XXX
# this doesn't use the env variable value
vulcan-local -t https://wordpress.org -i wpscan

# those are equivalents
vulcan-local -t https://wordpress.org -i wpscan -v WPVULNDB_API_TOKEN
vulcan-local -t https://wordpress.org -i wpscan -v WPVULNDB_API_TOKEN=XXX
vulcan-local -t https://wordpress.org -i wpscan -v WPVULNDB_API_TOKEN=$WPVULNDB_API_TOKEN
```
