### PR TITLE
fix: merge config when src values are not set to the zero value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,6 @@ package config
 import (
 	"fmt"
 	neturl "net/url"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -241,24 +240,9 @@ func ReadConfig(url string, cfg *Config, l log.Logger) error {
 	if err != nil {
 		return fmt.Errorf("unable to decode yaml %s: %w", url, err)
 	}
-	if err = mergo.Merge(cfg, newConfig, mergo.WithTransformers(sliceAppenderTransformer{}), mergo.WithOverride); err != nil {
+	if err = mergo.Merge(cfg, newConfig, mergo.WithAppendSlice, mergo.WithOverride); err != nil {
 		return fmt.Errorf("unable to merge config %s: %w", url, err)
 	}
 	l.Infof("Loaded config from url=%s", url)
-	return nil
-}
-
-type sliceAppenderTransformer struct {
-}
-
-func (t sliceAppenderTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
-	if typ.Kind() == reflect.Slice {
-		return func(dst, src reflect.Value) error {
-			if dst.CanSet() {
-				dst.Set(reflect.AppendSlice(dst, src))
-			}
-			return nil
-		}
-	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -241,7 +241,7 @@ func ReadConfig(url string, cfg *Config, l log.Logger) error {
 	if err != nil {
 		return fmt.Errorf("unable to decode yaml %s: %w", url, err)
 	}
-	if err = mergo.Merge(cfg, newConfig, mergo.WithTransformers(sliceAppenderTransformer{})); err != nil {
+	if err = mergo.Merge(cfg, newConfig, mergo.WithTransformers(sliceAppenderTransformer{}), mergo.WithOverride); err != nil {
 		return fmt.Errorf("unable to merge config %s: %w", url, err)
 	}
 	l.Infof("Loaded config from url=%s", url)


### PR DESCRIPTION
vulcal-local allows to specify a configuration file that overrides the default values of some configuration parameters, for instance, the severity threshold for a detected vulnerability to be reported. 
Before this modification the program was not honoring that configuration parameter, or any other parameter not set to the zero value of Its type, because the function ``mergo.Merge``  was not overriding the current value of a parameter with the new one (specified in the config file).  I modified the call to that function so now it overrides the parameters even if they are not set to its zero value.  