### PR TITLE
fix: set process quantum

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -165,6 +165,7 @@ func Run(cfg *config.Config, log *logrus.Logger) (int, error) {
 			ARN:               sqs.ArnChecks,
 			PollingInterval:   3,
 			VisibilityTimeout: 120,
+			ProcessQuantum:    90,
 		},
 		SQSWriter: agentconfig.SQSWriter{
 			Endpoint: sqs.Endpoint,

--- a/pkg/sqsservice/sqs.go
+++ b/pkg/sqsservice/sqs.go
@@ -27,7 +27,7 @@ Local:
   Port: ${PORT}
   AccountId: "${ACCOUNTID}"
   QueueAttributeDefaults:
-    VisibilityTimeout: 30
+    VisibilityTimeout: 120
     ReceiveMessageWaitTimeSeconds: 0
   Queues:
     - Name: Checks


### PR DESCRIPTION
the parameter `ProcessQuantum`  was not set and lead to a 0 timer in a loop for extending message visibility.

https://github.com/adevinta/vulcan-agent/blob/master/queue/sqs/reader.go#L235

I think Vulcan-agent should have a control in place to prevent this value to be 0.