### PR TITLE
net

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,27 +282,22 @@ docker run -p 1234:8000 --restart unless-stopped -d appsecco/dsvw
 Start scan using a local config file
 
 ```sh
-docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $PWD:/app \
-    -e TRAVIS_BUILD_DIR=/app -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
-    vulcan-local -c /app/vulcan.yaml
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+    -v $PWD:/target \
+    -e TRAVIS_BUILD_DIR=/target -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
+    vulcan-local -c /target/vulcan.yaml
 ```
 
 Start scanning a local http server
 
 ```sh
-docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
-    -v $PWD/script:/app/script \
-    vulcan-local -t http://localhost:1234 -checktypes /app/resources/checktypes.json
-    -v $PWD/resources:/app/resources \
-    -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
-    vulcan-local -t http://localhost:1234 -checktypes /app/resources/checktypes.json
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+    vulcan-local -t http://localhost:1234
 ```
 
-Start scanning a local Git repository. **The target path must point to the base of a git repository.**
+Start scanning a local directory
 
 ```sh
-docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock \
-  -v $PWD/resources:/app/resources -v $PWD:/src \
-  vulcan-local -t /src -checktypes /app/resources/checktypes.json
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/src \
+  vulcan-local -t /src
 ```

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -319,6 +319,10 @@ func getAgentIP(ifacename string, log agentlog.Logger) string {
 }
 
 func getHostIP(l agentlog.Logger) string {
+	if runtime.GOOS == "darwin" {
+		return defaultDockerHost
+	}
+
 	cmd := exec.Command("docker", "run", "--rm", "busybox:1.34.1", "sh", "-c", "ip route|awk '/default/ { print $3 }'")
 	var cmdOut bytes.Buffer
 	cmd.Stdout = &cmdOut

--- a/script/test.sh
+++ b/script/test.sh
@@ -15,7 +15,7 @@ echo "Test based on yaml config using internal-static policy"
 echo "exit=$?"
 
 echo "Test local path as a git repository excluding the github check"
-./vulcan-local -t . -e github -checktypes ./resources/checktypes.json
+./vulcan-local -t . -e github
 echo "exit=$?"
 
 # Add a path and a tag to bypass check target validations.
@@ -25,14 +25,14 @@ echo "Test local docker image"
 echo "exit=$?"
 
 echo "Docker test based on yaml config"
-docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock  \
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock  \
     -v "$PWD":/target -e TRAVIS_BUILD_DIR=/target \
     -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
     vulcan-local -c /target/vulcan.yaml -i retirejs
 echo "exit=$?"
 
 echo "Docker test local app as a webaddress excluding nessus and zap"
-docker run -i --rm -v /var/run/docker.sock:/var/run/docker.sock  \
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock  \
     -v "$PWD":/target \
     -e TRAVIS_BUILD_DIR=/target -e REGISTRY_SERVER -e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
     vulcan-local -t http://localhost:1234 -e '(nessus|zap)'

--- a/vulcan.yaml
+++ b/vulcan.yaml
@@ -10,9 +10,6 @@ conf:
     REGISTRY_USERNAME: ${REGISTRY_USERNAME}
     REGISTRY_PASSWORD: ${REGISTRY_PASSWORD}
 
-  repositories:
-    - ${TRAVIS_BUILD_DIR:-.}/resources/checktypes.json
-
   # Registry credentials to pull checks from private registries
   registries:
     - server: ${REGISTRY_SERVER}


### PR DESCRIPTION
- fix: checks unable to access darwin local targets not in docker

In MacOS

```sh
python3 -m http.server 1337
# WAS NOT able to access => INCONCLUSIVE
vulcan-local -t http://localhost:1337

docker run --rm -p 1337:1337 python python -m http.server 1337
# Is able to access => SUCCESS
vulcan-local -t http://localhost:1337  
```

- chore(docs): improve docs and test
