### PR TITLE
fix: docker client version 1.42 too new

### DIFF
--- a/pkg/checktypes/docker.go
+++ b/pkg/checktypes/docker.go
@@ -19,7 +19,7 @@ import (
 
 // buildDockerImage builds and image given a tar, a list of tags and labels.
 func buildDockerdImage(tarFile io.Reader, tags []string, labels map[string]string) (response string, err error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return "", err
 	}
@@ -41,7 +41,7 @@ func buildDockerdImage(tarFile io.Reader, tags []string, labels map[string]strin
 }
 
 func imageInfo(image string) (map[string]string, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In my env

```sh
docker version
Client:
 Version:           20.10.21-rd
 API version:       1.41
 Go version:        go1.18.7
 Git commit:        ac29474
 Built:             Tue Nov 22 22:20:01 2022
 OS/Arch:           darwin/amd64
 Context:           default
 Experimental:      true

Server: Docker Desktop 4.18.0 (104112)
 Engine:
  Version:          20.10.24
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.19.7
  Git commit:       5d6db84
  Built:            Tue Apr  4 18:18:42 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.18
  GitCommit:        2456e983eb9e37e47538f59ea18f2043c9a73640
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

When building a check on-the-fly

```
ERRO[2023-05-05T16:18:53+02:00] unable to generate checks Error response from daemon: client version 1.42 is too new. Maximum supported API version is 1.41
```

This pr fixes the issue.