### PR TITLE
feat: always include info about the executed checks

### DIFF
--- a/pkg/reporting/reporting.go
+++ b/pkg/reporting/reporting.go
@@ -212,6 +212,10 @@ func Generate(cfg *config.Config, results *results.ResultsServer, l log.Logger) 
 		// json: Just print the reports as an slice
 		m := map[string]*report.Report{}
 		slice := []*report.Report{}
+		for _, r := range results.Checks {
+			m[r.CheckID] = r
+			slice = append(slice, r)
+		}
 		for _, e := range vs {
 			r, ok := m[e.CheckID]
 			if !ok {


### PR DESCRIPTION
This pr modifies the json report adding the info about the checks executed regardless if there is a vulnerability or not.

i.e. when executed a faulty check it returns 

```json
[
    {
        "check_id": "84179df0-2f97-459e-aa56-9b2cd8a40c6e",
        "checktype_name": "vulcan-trivy-local",
        "checktype_version": "latest",
        "status": "RUNNING",
        "target": "http://host.docker.internal:52715/",
        "options": "{\"branch\":\"\",\"depth\":1,\"disable_custom_secret_config\":false,\"git_checks\":{\"config\":false,\"secret\":true,\"vuln\":false},\"image_checks\":{\"config\":false,\"secret\":false,\"vuln\":true}}",
        "tag": "",
        "start_time": "2023-05-05T15:36:33.607401743Z",
        "end_time": "0001-01-01T00:00:00Z",
        "vulnerabilities": null,
        "error": ""
    }
]
```

Or if no vulns:
```sh
vulcan-local -t alpine:latest -a DockerImage -i trivy -r - | jq .
INFO[2023-05-05T17:46:00+02:00] No checktypes specified. Using default https://raw.githubusercontent.com/adevinta/vulcan-local/master/resources/checktypes.json
INFO[2023-05-05T17:46:00+02:00] Check name=vulcan-trivy image=vulcansec/vulcan-trivy:edge target=alpine:latest type=DockerImage id=69f7b0aa-8b17-44d6-87cd-b9b1de05378c
INFO[2023-05-05T17:46:06+02:00] Check progress [FINISHED:1]
INFO[2023-05-05T17:46:06+02:00]
Check summary:

 - image=vulcansec/vulcan-trivy:edge target=alpine:latest assetType=DockerImage status=FINISHED duration=0.861953

INFO[2023-05-05T17:46:06+02:00] No vulnerabilities found during the last scan
```

```json
[
  {
    "check_id": "69f7b0aa-8b17-44d6-87cd-b9b1de05378c",
    "checktype_name": "vulcansec/vulcan-trivy",
    "checktype_version": "edge",
    "status": "FINISHED",
    "target": "alpine:latest",
    "options": "{\"branch\":\"\",\"depth\":1,\"git_checks\":{\"config\":true,\"secret\":true,\"vuln\":true},\"image_checks\":{\"config\":true,\"secret\":true,\"vuln\":true}}",
    "tag": "",
    "start_time": "2023-05-05T15:46:03.250869499Z",
    "end_time": "2023-05-05T15:46:04.112822613Z",
    "vulnerabilities": null,
    "error": ""
  }
]
```

This provides valuable information about what was executed.
