### PR TITLE
feat(deps): bump p4tin/goaws v1.1.2 to Admiral-Piett/goaws v0.4.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 // replace github.com/adevinta/vulcan-agent => ../vulcan-agent
 
 require (
+	github.com/Admiral-Piett/goaws v0.4.1
 	github.com/adevinta/vulcan-agent v1.1.0
 	github.com/adevinta/vulcan-report v1.0.0
 	github.com/adevinta/vulcan-types v1.0.1
@@ -17,7 +18,6 @@ require (
 	github.com/jesusfcr/gittp v0.0.0-20211215162506-673d6dfd0f2b
 	github.com/manelmontilla/toml v0.3.0
 	github.com/otiai10/copy v1.11.0
-	github.com/p4tin/goaws v1.1.2
 	github.com/sirupsen/logrus v1.9.2
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Admiral-Piett/goaws v0.4.1 h1:DXvGcNHAC/PX29qVtKJ8QiTZMEW04KkwK2wovPg6kc8=
+github.com/Admiral-Piett/goaws v0.4.1/go.mod h1:h7bGSPqvKexl0Zx1hn08jDFIT3w2glf9oSLSO+GpgME=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
@@ -112,8 +114,6 @@ github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/otiai10/copy v1.11.0 h1:OKBD80J/mLBrwnzXqGtFCzprFSGioo30JcmR4APsNwc=
 github.com/otiai10/copy v1.11.0/go.mod h1:rSaLseMUsZFFbsFGc7wCJnnkTAvdc5L6VWxPE4308Ww=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
-github.com/p4tin/goaws v1.1.2 h1:xPj+z+cpJIGV82l0H5KChqJ3GnWXt06VUPr97z5PPT8=
-github.com/p4tin/goaws v1.1.2/go.mod h1:pu7i+//316+cGxI3QaV/D/yi7Rj9uM068evG0qDb6M4=
 github.com/pjbgf/sha1cd v0.3.0 h1:4D5XXmUUBUl/xQ6IjCkEAbqXskkq/4O7LmGn0AqMDs4=
 github.com/pjbgf/sha1cd v0.3.0/go.mod h1:nZ1rrWOcGJ5uZgEEVL1VUM9iRQiZvWdbZjkKyFzPPsI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/sqsservice/sqs.go
+++ b/pkg/sqsservice/sqs.go
@@ -13,10 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Admiral-Piett/goaws/app/conf"
+	"github.com/Admiral-Piett/goaws/app/gosqs"
+	"github.com/Admiral-Piett/goaws/app/router"
 	"github.com/adevinta/vulcan-agent/log"
-	"github.com/p4tin/goaws/app/conf"
-	"github.com/p4tin/goaws/app/gosqs"
-	"github.com/p4tin/goaws/app/router"
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Looks like goaws has changed ownership to Admiral-Piett and finally seems live again.

Also we were using v1.1.2 version that was not the last one (see https://github.com/Admiral-Piett/goaws/releases)

Will wait for dependabot but probably we should config it to ignore goaws.