### PR TITLE
chore(ci): fix goreleaser deprecations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,9 @@ archives:
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
+    format_overrides:
+    - goos: windows
+      format: zip
 
 dockers:
   -

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,16 +32,12 @@ builds:
     -X main.builtBy=goreleaser
 
 archives:
-  - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    format_overrides:
-    - goos: windows
-      format: zip
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 
 dockers:
   -

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ go:
   - 1.19.x
 services:
   - docker
+before_script: curl -sfL https://github.com/goreleaser/goreleaser/releases/download/v1.19.1/goreleaser_Linux_x86_64.tar.gz | tar xzvf - --directory /usr/local/bin goreleaser
 script:
   - go test ./...
-  - curl -sfL https://git.io/goreleaser | VERSION=v1.19.1 bash -s -- build --clean --single-target --snapshot --output ./vulcan-local
+  - goreleaser build --clean --single-target --snapshot --output ./vulcan-local
   - docker build . -t vulcan-local
   - ./script/test.sh
 after_success:
@@ -13,7 +14,7 @@ after_success:
 deploy:
   - provider: script
     cleanup: false
-    script: curl -sfL https://goreleaser.com/static/run | VERSION=v1.19.1 bash -s --
+    script: goreleaser
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 script:
   - go test ./...
-  - curl -sfL https://git.io/goreleaser | sh -s -- build --rm-dist --single-target --snapshot --output ./vulcan-local
+  - curl -sfL https://git.io/goreleaser | sh -s -- build --clean --single-target --snapshot --output ./vulcan-local
   - docker build . -t vulcan-local
   - ./script/test.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - docker
 script:
   - go test ./...
-  - curl -sfL https://goreleaser.com/static/run | VERSION=v1.19.1 bash -s -- build --clean --single-target --snapshot --output ./vulcan-local
+  - curl -sfL https://git.io/goreleaser | VERSION=v1.19.1 bash -s -- build --clean --single-target --snapshot --output ./vulcan-local
   - docker build . -t vulcan-local
   - ./script/test.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ go:
   - 1.19.x
 services:
   - docker
+before_script: go install github.com/goreleaser/goreleaser@v1.19.1
 script:
   - go test ./...
-  - curl -sfL https://git.io/goreleaser | sh -s -- build --clean --single-target --snapshot --output ./vulcan-local
+  - goreleaser build --clean --single-target --snapshot --output ./vulcan-local
   - docker build . -t vulcan-local
   - ./script/test.sh
 after_success:
@@ -13,7 +14,7 @@ after_success:
 deploy:
   - provider: script
     cleanup: false
-    script: curl -sfL https://git.io/goreleaser | sh -s --
+    script: goreleaser
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ go:
   - 1.19.x
 services:
   - docker
-before_script: go install github.com/goreleaser/goreleaser@v1.19.1
 script:
   - go test ./...
-  - goreleaser build --clean --single-target --snapshot --output ./vulcan-local
+  - curl -sfL https://goreleaser.com/static/run | VERSION=v1.19.1 bash -s -- build --clean --single-target --snapshot --output ./vulcan-local
   - docker build . -t vulcan-local
   - ./script/test.sh
 after_success:
@@ -14,7 +13,7 @@ after_success:
 deploy:
   - provider: script
     cleanup: false
-    script: goreleaser
+    script: curl -sfL https://goreleaser.com/static/run | VERSION=v1.19.1 bash -s --
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ go:
   - 1.19.x
 services:
   - docker
-before_script: curl -sfL https://github.com/goreleaser/goreleaser/releases/download/v1.19.1/goreleaser_Linux_x86_64.tar.gz | tar xzvf - --directory /usr/local/bin goreleaser
+before_script: curl -sfL https://github.com/goreleaser/goreleaser/releases/download/v1.19.1/goreleaser_Linux_x86_64.tar.gz | tar xzvf - goreleaser
 script:
   - go test ./...
-  - goreleaser build --clean --single-target --snapshot --output ./vulcan-local
+  - ./goreleaser build --clean --single-target --snapshot --output ./vulcan-local
   - docker build . -t vulcan-local
   - ./script/test.sh
 after_success:
@@ -14,7 +14,7 @@ after_success:
 deploy:
   - provider: script
     cleanup: false
-    script: goreleaser
+    script: ./goreleaser
     on:
       tags: true
       condition: $TRAVIS_OS_NAME = linux


### PR DESCRIPTION
Goreleaser deprecated archive.replacements see <https://goreleaser.com/deprecations/#archivesreplacements>
This pr applies the documented solution and pins the latest version.